### PR TITLE
feat: Allocate 100% of free memory by default

### DIFF
--- a/gpu_burn-drv.cpp
+++ b/gpu_burn-drv.cpp
@@ -29,7 +29,7 @@
 
 // Matrices are SIZE*SIZE..  POT should be efficiently implemented in CUBLAS
 #define SIZE 8192ul
-#define USEMEM 0.9 // Try to allocate 90% of memory
+#define USEMEM 1.0 // Try to allocate 100% of free memory
 #define COMPARE_KERNEL "compare.ptx"
 
 // Used to report op/s, measured through Visual Profiler, CUBLAS from CUDA 7.5


### PR DESCRIPTION
Since GPUBurn checks free memory for it's default memory allocation, doing 100% is safe and will provide maximum coverage.